### PR TITLE
Use MultiJson instead of YAJL

### DIFF
--- a/faye-redis.gemspec
+++ b/faye-redis.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "eventmachine", ">= 0.12.0"
   s.add_dependency "em-hiredis", ">= 0.0.1"
-  s.add_dependency "yajl-ruby", ">= 1.0.0"
+  s.add_dependency "multi_json", "~> 1.7.0"
 
   s.add_development_dependency "rspec", "~> 2.8.0"
 end

--- a/lib/faye/redis.rb
+++ b/lib/faye/redis.rb
@@ -1,5 +1,5 @@
 require 'em-hiredis'
-require 'yajl'
+require 'multi_json'
 
 module Faye
   class Redis
@@ -136,7 +136,7 @@ module Faye
       init
       @server.debug 'Publishing message ?', message
       
-      json_message = Yajl::Encoder.encode(message)
+      json_message = MultiJson.dump(message)
       channels     = Channel.expand(message['channel'])
       keys         = channels.map { |c| @ns + "/channels#{c}" }
       
@@ -161,7 +161,7 @@ module Faye
       @redis.lrange(key, 0, -1)
       @redis.del(key)
       @redis.exec.callback  do |json_messages, deleted|
-        messages = json_messages.map { |json| Yajl::Parser.parse(json) }
+        messages = json_messages.map { |json| MultiJson.load(json) }
         @server.deliver(client_id, messages)
       end
     end


### PR DESCRIPTION
Depending on YAJL means that many apps will require multiple JSON libraries to be loaded in their codebase, which obviously isn't ideal for a number of reasons. This PR simply replaces the YAJL dependency with MultiJson, enabling users to pick the backend they are currently using.
