### PR TITLE
Added a subscribe on the :failed event of @subscriber

### DIFF
--- a/lib/faye/redis.rb
+++ b/lib/faye/redis.rb
@@ -53,6 +53,10 @@ module Faye
       end
 
       @gc = EventMachine.add_periodic_timer(gc, &method(:gc))
+      @subscriber.on(:failed) do
+        disconnect
+        raise "Could not connect to redis"
+      end
     end
 
     def disconnect


### PR DESCRIPTION
At the moment, a failure to (re)connect to redis is not correctly
exposed by this engine. Failure occurs silently, without any messages.
By subscribing to the :failed event the PubSub-client, the Faye-Redis
engine is notified when a connection failure is happening, and will
raise an error, which is useful for users.

This commit came to life after a hunt for a non-functioning deployment
in which ultimately a non-started Redis database was to blame. It would
have been nice if an error would have been raised.
