### PR TITLE
Adds sentinel support

### DIFF
--- a/faye-redis.gemspec
+++ b/faye-redis.gemspec
@@ -14,8 +14,10 @@ Gem::Specification.new do |s|
             Dir.glob('lib/**/*.rb')
 
   s.add_dependency 'eventmachine', '>= 0.12.0'
-  s.add_dependency 'em-hiredis', '>= 0.2.0'
+  s.add_dependency 'em-hiredis', '>= 0.3.0'
   s.add_dependency 'multi_json', '>= 1.0.0'
+  s.add_dependency 'em-hiredis-sentinel', '>= 0.2.3'
+
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-eventmachine'


### PR DESCRIPTION
I thought it would be wonderful to provide faye-redis gem with redis-sentinel support. In order to achieve that I added this gem https://github.com/livehelpnow/em-hiredis-sentinel  into faye-redis.
In short sentinels in redis give us more reliable  and stable redis.  The complete description of sentinels could be seen here http://redis.io/topics/sentinel
I will be very happy if you guys comment my pull request and say what do you think about  sentinels idea.