### PR TITLE
Adds sentinels support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,27 @@ The full list of settings is as follows.
 * <b>`:database`</b> - number of database to use, default is `0`
 * <b>`:namespace`</b> - prefix applied to all keys, default is `''`
 * <b>`:socket`</b> - path to Unix socket if `unixsocket` is set
+* <b>`:master_name`</b> - name of the master, controlling sentinels, default is `nil`
+* <b>`:sentinels`</b> - array of sentinels, default is `nil`
 
+Sentinels could be specified as follows
+
+```rb
+sentinels = [
+    'your_redis_host.com:26379',
+    'your_redis_host.com:26380',
+    'your_redis_host.com:26381'
+  ]
+
+sentinels = [
+    {url:'blah://sentinel5.example.net:26381'},
+    {url:'blah://sentinel5.example.net:26382'},
+    {url:'blah://sentinel5.example.net:26383'}
+  ]
+```
+When you specify sentinels, you should also specify master name.
+Gem  em-hiredis-sentinel is used in order to get sentinel technology support
+https://github.com/livehelpnow/em-hiredis-sentinel
 
 ## License
 

--- a/faye-redis.gemspec
+++ b/faye-redis.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |s|
             Dir.glob('lib/**/*.rb')
 
   s.add_dependency 'eventmachine', '>= 0.12.0'
-  s.add_dependency 'em-hiredis', '>= 0.2.0'
+  s.add_dependency 'em-hiredis', '>= 0.3.0'
   s.add_dependency 'multi_json', '>= 1.0.0'
+  s.add_dependency 'em-hiredis-sentinel', '>= 0.2.3'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-eventmachine'


### PR DESCRIPTION
Dear Faye::Redis developers
Please consider this request. The main idea of this pull requiest is to add Sentinel technology support. (Provides high availability for redis http://redis.io/topics/sentinel)
In order to achieve the desired result I used em-hiredis-sentinel gem. With this pull request applied one could  use Sentinel technology by simply specifying the list of Sentinels when connecting to Faye. 
Like
```rb
Faye::RackAdapter.new(
  :mount   => '/',
  :timeout => 25,
  :engine  => {
    :type  => Faye::Redis,
    sentinels: ['your_redis.com:26379', 'your_redis.com:26380', 'your_redis.com:26381'],
    master_name: 'mymaster',
  }
)
```

Sincerely yours Maksim